### PR TITLE
GET params handling

### DIFF
--- a/InstagramStrategy.php
+++ b/InstagramStrategy.php
@@ -44,8 +44,7 @@ class InstagramStrategy extends OpauthStrategy {
 			$params['response_type'] = $this->strategy['response_type'];
 		
 		// redirect to generated url
-		// NOTE: have to decode url because Instagram display error page e.g. scope=likes+comments
-		$this->redirect($url.'?'.urldecode(http_build_query($params, '', '&')));
+		$this->clientGet($url, $params);
 	}
 	
 	/**

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Required parameters:
 ```
 
 Optional parameters:
-`scope`, `response_type`
+`scope`, `response_type`  
+For `scope`, separate each scopes with a space(' ') and not a plus sign ('+'). Eg. `likes comments`.
 
 
 References


### PR DESCRIPTION
Using `clientGet()` instead of building own params with `redirect()`.

Also, scope separator is really simply space instead of plus, even though http://instagr.am/developer/authentication/#scope uses the "escaped space".

Doing decoding like that may end up affecting other parameters' URL encoding.
