### PR TITLE
quick fix for Instagram's API bug, to ensure valid JSON

### DIFF
--- a/InstagramStrategy.php
+++ b/InstagramStrategy.php
@@ -62,6 +62,10 @@ class InstagramStrategy extends OpauthStrategy {
 				'code' => trim($_GET['code'])
 			);
 			$response = $this->serverPost($url, $params, null, $headers);
+
+			while (substr($response, -1) != '}') {
+				$response = substr($response, 0, -1);
+			}
 			
 			$results = json_decode($response);
 			

--- a/InstagramStrategy.php
+++ b/InstagramStrategy.php
@@ -140,10 +140,10 @@ class InstagramStrategy extends OpauthStrategy {
 		
 		if (!empty($userinfo)){
 			while (substr($userinfo, -1) != '}') {
-                $userinfo = substr($userinfo, 0, -1);
-            }
+				$userinfo = substr($userinfo, 0, -1);
+			}
 
-            $results = json_decode($userinfo);
+			$results = json_decode($userinfo);
 			
 			return $results->data;
 		}

--- a/InstagramStrategy.php
+++ b/InstagramStrategy.php
@@ -139,7 +139,11 @@ class InstagramStrategy extends OpauthStrategy {
 		$userinfo = $this->serverGet('https://api.instagram.com/v1/users/'.$uid.'/', array('access_token' => $access_token), null, $headers);
 		
 		if (!empty($userinfo)){
-			$results = json_decode($userinfo);
+			while (substr($userinfo, -1) != '}') {
+                $userinfo = substr($userinfo, 0, -1);
+            }
+
+            $results = json_decode($userinfo);
 			
 			return $results->data;
 		}


### PR DESCRIPTION
Instagram's OAuth service seems to be buggy : every response I get from it consists of valid JSON appended with a random character (most of the time something unprintable, displayed as the dreaded black diamond, but I had a couple of t's, f's and ^'s).

Example : `{"access_token":"some.access.token","user":{"username":"someuser","bio":"","website":"","profile_picture":"http:\/\/images.ak.instagram.com\/profiles\/anonymousUser.jpg","full_name":"","id":"someid"}}f`

This does not seem to be related to Opauth or to this very Strategy as the extra character is already present in the raw JSON returned by `file_get_contents` (OpauthStrategy.php, line 422).

This **quick and dirty** fix (certainly not meant to last) aims at going around this problem for now, by right-trimming the returned JSON while its last character is not `}`.

**I will understand perfectly if you don't merge this, but at least people will be able to know of and use my fork if they need to.**
